### PR TITLE
Fix client queue and transport issues, add keep-alive function

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,7 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(python3:*)"
-    ]
-  }
-}

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ Thumbs.db
 
 # Local development documentation (was French)
 AGENTS.md
+.claude/
 
 # Submodule changes (to avoid automatic commits)
 # Note: This helps with the submodule issue mentioned by user

--- a/library.json
+++ b/library.json
@@ -1,6 +1,6 @@
 {
   "name": "ESP-Reverse_Tunneling_Libssh2",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "keywords": "esp32, arduino, ssh, tunnel, reverse, libssh2",
   "description": "Library for ESP32 Arduino enabling creation of reverse SSH tunnels using libssh2.",
   "license": "MIT",

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ESP-Reverse_Tunneling_Libssh2
-version=2.1.1
+version=2.1.2
 author=Playmiel 
 maintainer=Playmiel 
 sentence=ESP32 library for reverse SSH tunneling using libssh2_esp.

--- a/src/ssh_channel.cpp
+++ b/src/ssh_channel.cpp
@@ -355,13 +355,22 @@ int ChannelManager::connectToLocalEndpoint(const TunnelConfig &mapping) {
 
   // Set non-blocking BEFORE connect to avoid stalling the entire loop()
   int flags = fcntl(localSocket, F_GETFL, 0);
-  fcntl(localSocket, F_SETFL, flags | O_NONBLOCK);
+  if (flags < 0) {
+    LOGF_E("SSH", "fcntl F_GETFL failed for local socket (errno=%d)", errno);
+    close(localSocket);
+    return -1;
+  }
+  if (fcntl(localSocket, F_SETFL, flags | O_NONBLOCK) < 0) {
+    LOGF_E("SSH", "fcntl F_SETFL failed for local socket (errno=%d)", errno);
+    close(localSocket);
+    return -1;
+  }
 
   int connectResult =
       ::connect(localSocket, (struct sockaddr *)&addr, sizeof(addr));
   if (connectResult < 0 && errno != EINPROGRESS) {
-    LOGF_E("SSH", "Failed to connect to local endpoint %s:%d",
-           mapping.localHost.c_str(), mapping.localPort);
+    LOGF_E("SSH", "Failed to connect to local endpoint %s:%d (errno=%d)",
+           mapping.localHost.c_str(), mapping.localPort, errno);
     close(localSocket);
     return -1;
   }
@@ -375,7 +384,13 @@ int ChannelManager::connectToLocalEndpoint(const TunnelConfig &mapping) {
     tv.tv_sec = 2; // 2 second max wait (was potentially 20-75s blocking)
     tv.tv_usec = 0;
     int sel = select(localSocket + 1, nullptr, &writefds, nullptr, &tv);
-    if (sel <= 0) {
+    if (sel < 0) {
+      LOGF_E("SSH", "select() error connecting to %s:%d (errno=%d)",
+             mapping.localHost.c_str(), mapping.localPort, errno);
+      close(localSocket);
+      return -1;
+    }
+    if (sel == 0 || !FD_ISSET(localSocket, &writefds)) {
       LOGF_E("SSH", "Timeout connecting to local endpoint %s:%d",
              mapping.localHost.c_str(), mapping.localPort);
       close(localSocket);
@@ -384,7 +399,12 @@ int ChannelManager::connectToLocalEndpoint(const TunnelConfig &mapping) {
     // Check if connect actually succeeded
     int sockErr = 0;
     socklen_t errLen = sizeof(sockErr);
-    getsockopt(localSocket, SOL_SOCKET, SO_ERROR, &sockErr, &errLen);
+    if (getsockopt(localSocket, SOL_SOCKET, SO_ERROR, &sockErr, &errLen) != 0) {
+      LOGF_E("SSH", "getsockopt SO_ERROR failed for %s:%d (errno=%d)",
+             mapping.localHost.c_str(), mapping.localPort, errno);
+      close(localSocket);
+      return -1;
+    }
     if (sockErr != 0) {
       LOGF_E("SSH", "Failed to connect to local endpoint %s:%d (err=%d)",
              mapping.localHost.c_str(), mapping.localPort, sockErr);

--- a/src/ssh_channel.cpp
+++ b/src/ssh_channel.cpp
@@ -357,7 +357,8 @@ int ChannelManager::connectToLocalEndpoint(const TunnelConfig &mapping) {
   int flags = fcntl(localSocket, F_GETFL, 0);
   fcntl(localSocket, F_SETFL, flags | O_NONBLOCK);
 
-  int connectResult = ::connect(localSocket, (struct sockaddr *)&addr, sizeof(addr));
+  int connectResult =
+      ::connect(localSocket, (struct sockaddr *)&addr, sizeof(addr));
   if (connectResult < 0 && errno != EINPROGRESS) {
     LOGF_E("SSH", "Failed to connect to local endpoint %s:%d",
            mapping.localHost.c_str(), mapping.localPort);
@@ -371,7 +372,7 @@ int ChannelManager::connectToLocalEndpoint(const TunnelConfig &mapping) {
     FD_ZERO(&writefds);
     FD_SET(localSocket, &writefds);
     struct timeval tv;
-    tv.tv_sec = 2;  // 2 second max wait (was potentially 20-75s blocking)
+    tv.tv_sec = 2; // 2 second max wait (was potentially 20-75s blocking)
     tv.tv_usec = 0;
     int sel = select(localSocket + 1, nullptr, &writefds, nullptr, &tv);
     if (sel <= 0) {

--- a/src/ssh_channel.cpp
+++ b/src/ssh_channel.cpp
@@ -5,6 +5,7 @@
 #include <esp_heap_caps.h>
 #include <fcntl.h>
 #include <netinet/in.h>
+#include <sys/select.h>
 #include <sys/socket.h>
 #include <unistd.h>
 
@@ -352,20 +353,48 @@ int ChannelManager::connectToLocalEndpoint(const TunnelConfig &mapping) {
     return -1;
   }
 
-  if (::connect(localSocket, (struct sockaddr *)&addr, sizeof(addr)) < 0) {
+  // Set non-blocking BEFORE connect to avoid stalling the entire loop()
+  int flags = fcntl(localSocket, F_GETFL, 0);
+  fcntl(localSocket, F_SETFL, flags | O_NONBLOCK);
+
+  int connectResult = ::connect(localSocket, (struct sockaddr *)&addr, sizeof(addr));
+  if (connectResult < 0 && errno != EINPROGRESS) {
     LOGF_E("SSH", "Failed to connect to local endpoint %s:%d",
            mapping.localHost.c_str(), mapping.localPort);
     close(localSocket);
     return -1;
   }
 
+  if (connectResult != 0) {
+    // Non-blocking connect in progress — wait with a short timeout
+    fd_set writefds;
+    FD_ZERO(&writefds);
+    FD_SET(localSocket, &writefds);
+    struct timeval tv;
+    tv.tv_sec = 2;  // 2 second max wait (was potentially 20-75s blocking)
+    tv.tv_usec = 0;
+    int sel = select(localSocket + 1, nullptr, &writefds, nullptr, &tv);
+    if (sel <= 0) {
+      LOGF_E("SSH", "Timeout connecting to local endpoint %s:%d",
+             mapping.localHost.c_str(), mapping.localPort);
+      close(localSocket);
+      return -1;
+    }
+    // Check if connect actually succeeded
+    int sockErr = 0;
+    socklen_t errLen = sizeof(sockErr);
+    getsockopt(localSocket, SOL_SOCKET, SO_ERROR, &sockErr, &errLen);
+    if (sockErr != 0) {
+      LOGF_E("SSH", "Failed to connect to local endpoint %s:%d (err=%d)",
+             mapping.localHost.c_str(), mapping.localPort, sockErr);
+      close(localSocket);
+      return -1;
+    }
+  }
+
   if (!NetworkOptimizer::optimizeSocket(localSocket)) {
     LOG_W("SSH", "Failed to optimize local socket");
   }
-
-  // Set non-blocking
-  int flags = fcntl(localSocket, F_GETFL, 0);
-  fcntl(localSocket, F_SETFL, flags | O_NONBLOCK);
 
   return localSocket;
 }

--- a/src/ssh_session.h
+++ b/src/ssh_session.h
@@ -39,6 +39,9 @@ public:
   // True if session is live and socket is valid.
   bool isConnected() const;
 
+  // Number of consecutive keepalive failures seen since the last success.
+  int getKeepAliveFailures() const { return keepAliveFailures_; }
+
   // Send SSH keepalive. Returns false if the connection should be considered
   // dead.
   bool sendKeepalive();

--- a/src/ssh_transport.cpp
+++ b/src/ssh_transport.cpp
@@ -127,11 +127,29 @@ void TransportPump::pumpSshTransport() {
               ch.toLocal->available() < 64 ? ch.toLocal->available() : 64;
           int rc =
               libssh2_channel_read(ch.sshChannel, (char *)rxBuf_, pumpSize);
+          anyReadDone = true;
           if (rc > 0) {
-            ch.toLocal->write(rxBuf_, rc);
+            size_t written = ch.toLocal->write(rxBuf_, rc);
+            ch.totalBytesReceived += written;
+            lastBytesMoved_ += written;
+            ch.lastSuccessfulRead = millis();
+            ch.lastActivity = ch.lastSuccessfulRead;
+            ch.eagainCount = 0;
+            ch.firstEagainMs = 0;
+            ch.consecutiveErrors = 0;
+          } else if (rc == 0) {
+            ch.remoteEof = true;
+            LOGF_I("SSH", "Channel %d: remote EOF (paused read)", i);
+          } else if (rc != LIBSSH2_ERROR_EAGAIN) {
+            ch.consecutiveErrors++;
+            LOGF_W("SSH", "Channel %d: SSH read error %d (errors=%d)", i, rc,
+                   ch.consecutiveErrors);
+            if (ch.consecutiveErrors > 3 &&
+                ch.state == ChannelSlot::State::Open) {
+              channels_->beginClose(i, ChannelCloseReason::Error);
+            }
           }
         }
-        anyReadDone = true;
         continue;
       }
     }
@@ -198,12 +216,24 @@ void TransportPump::pumpSshTransport() {
   // pump the transport via a 1-byte read on a remoteEof channel (safe, no
   // useful data left) or any active channel as last resort.
   if (!anyReadDone) {
+    bool fallbackDone = false;
     for (int i = 0; i < maxSlots; ++i) {
       ChannelSlot &ch = channels_->getSlot(i);
       if (ch.active && ch.sshChannel && ch.remoteEof) {
         char pumpBuf[1];
         libssh2_channel_read(ch.sshChannel, pumpBuf, sizeof(pumpBuf));
+        fallbackDone = true;
         break;
+      }
+    }
+    if (!fallbackDone) {
+      for (int i = 0; i < maxSlots; ++i) {
+        ChannelSlot &ch = channels_->getSlot(i);
+        if (ch.active && ch.sshChannel && !ch.remoteEof) {
+          char pumpBuf[1];
+          libssh2_channel_read(ch.sshChannel, pumpBuf, sizeof(pumpBuf));
+          break;
+        }
       }
     }
   }
@@ -335,9 +365,16 @@ void TransportPump::drainLocalToSsh() {
               ch.firstEagainMs = millis();
             hitEagain = true;
           } else {
+            if (ch.toRemote->writeToFront(txBuf_, got) == 0) {
+              ch.toRemote->write(txBuf_, got);
+            }
             ch.consecutiveErrors++;
             LOGF_W("SSH", "Channel %d: SSH write error %ld (errors=%d)", i,
                    (long)written, ch.consecutiveErrors);
+            if (ch.consecutiveErrors > 3 &&
+                ch.state == ChannelSlot::State::Open) {
+              channels_->beginClose(i, ChannelCloseReason::Error);
+            }
             break;
           }
         }

--- a/src/ssh_transport.cpp
+++ b/src/ssh_transport.cpp
@@ -224,7 +224,10 @@ void TransportPump::drainSshToLocal() {
       ch.lastActivity = millis();
       if (static_cast<size_t>(sent) < got) {
         // Partial send: put unsent data back at the front of the ring
-        ch.toLocal->writeToFront(txBuf_ + sent, got - sent);
+        if (ch.toLocal->writeToFront(txBuf_ + sent, got - sent) == 0) {
+          // Prepend buffer occupied — re-append to preserve data
+          ch.toLocal->write(txBuf_ + sent, got - sent);
+        }
       }
     } else if (sent < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
       ch.localEof = true;
@@ -232,7 +235,9 @@ void TransportPump::drainSshToLocal() {
              strerror(errno));
     } else {
       // EAGAIN/EWOULDBLOCK: put ALL data back at the front
-      ch.toLocal->writeToFront(txBuf_, got);
+      if (ch.toLocal->writeToFront(txBuf_, got) == 0) {
+        ch.toLocal->write(txBuf_, got);
+      }
     }
   }
 }
@@ -251,10 +256,6 @@ void TransportPump::drainLocalToSsh() {
     return;
   }
 
-  if (!session_->lock(pdMS_TO_TICKS(50))) {
-    return;
-  }
-
   for (int n = 0; n < maxSlots; ++n) {
     int i = (n + roundRobinOffset_) % maxSlots;
     ChannelSlot &ch = channels_->getSlot(i);
@@ -262,64 +263,70 @@ void TransportPump::drainLocalToSsh() {
       continue;
     }
 
-    // --- Step A: Drain toRemote -> SSH using writeToFront() for partial writes
-    // --- Data goes: ring.read() -> SSH write. Unsent remainder ->
-    // ring.writeToFront().
-    if (ch.toRemote) {
-      size_t budget = MAX_WRITE_PER_CHANNEL;
-      bool hitEagain = false;
+    // --- Step A: Drain toRemote -> SSH (requires session lock) ---
+    if (ch.toRemote && !ch.toRemote->empty()) {
+      if (session_->lock(pdMS_TO_TICKS(20))) {
+        size_t budget = MAX_WRITE_PER_CHANNEL;
+        bool hitEagain = false;
 
-      while (budget > 0 && !ch.toRemote->empty() && !hitEagain) {
-        size_t chunkSize = budget < bufSize_ ? budget : bufSize_;
-        size_t got = ch.toRemote->read(txBuf_, chunkSize);
-        if (got == 0)
-          break;
+        while (budget > 0 && !ch.toRemote->empty() && !hitEagain) {
+          size_t chunkSize = budget < bufSize_ ? budget : bufSize_;
+          size_t got = ch.toRemote->read(txBuf_, chunkSize);
+          if (got == 0)
+            break;
 
-        ssize_t written =
-            libssh2_channel_write(ch.sshChannel, (char *)txBuf_, got);
-        if (written > 0) {
-          ch.totalBytesSent += written;
-          lastBytesMoved_ += written;
-          budget -= written;
-          ch.lastSuccessfulWrite = millis();
-          ch.lastActivity = ch.lastSuccessfulWrite;
-          ch.eagainCount = 0;
-          ch.firstEagainMs = 0;
-          ch.consecutiveErrors = 0;
-          if (static_cast<size_t>(written) < got) {
-            // Partial write: put unsent data back at the front
-            ch.toRemote->writeToFront(txBuf_ + written, got - written);
+          ssize_t written =
+              libssh2_channel_write(ch.sshChannel, (char *)txBuf_, got);
+          if (written > 0) {
+            ch.totalBytesSent += written;
+            lastBytesMoved_ += written;
+            budget -= written;
+            ch.lastSuccessfulWrite = millis();
+            ch.lastActivity = ch.lastSuccessfulWrite;
+            ch.eagainCount = 0;
+            ch.firstEagainMs = 0;
+            ch.consecutiveErrors = 0;
+            if (static_cast<size_t>(written) < got) {
+              if (ch.toRemote->writeToFront(txBuf_ + written,
+                                            got - written) == 0) {
+                ch.toRemote->write(txBuf_ + written, got - written);
+              }
+              break;
+            }
+          } else if (written == LIBSSH2_ERROR_EAGAIN) {
+            if (ch.toRemote->writeToFront(txBuf_, got) == 0) {
+              ch.toRemote->write(txBuf_, got);
+            }
+            ch.eagainCount++;
+            if (ch.firstEagainMs == 0)
+              ch.firstEagainMs = millis();
+            hitEagain = true;
+          } else {
+            ch.consecutiveErrors++;
+            LOGF_W("SSH", "Channel %d: SSH write error %ld (errors=%d)", i,
+                   (long)written, ch.consecutiveErrors);
             break;
           }
-        } else if (written == LIBSSH2_ERROR_EAGAIN) {
-          // Put ALL data back at the front of the ring
-          ch.toRemote->writeToFront(txBuf_, got);
-          ch.eagainCount++;
-          if (ch.firstEagainMs == 0)
-            ch.firstEagainMs = millis();
-          hitEagain = true;
-        } else {
-          ch.consecutiveErrors++;
-          LOGF_W("SSH", "Channel %d: SSH write error %ld (errors=%d)", i,
-                 (long)written, ch.consecutiveErrors);
-          break;
         }
-      }
 
-      // Check EAGAIN stall timeout
-      if (ch.firstEagainMs > 0 &&
-          (millis() - ch.firstEagainMs) >
-              static_cast<unsigned long>(EAGAIN_STALL_TIMEOUT_MS)) {
-        LOGF_W("SSH", "Channel %d: EAGAIN stall timeout (%dms, toRemote=%zu)",
-               i, EAGAIN_STALL_TIMEOUT_MS, ch.toRemote->size());
-        if (ch.state == ChannelSlot::State::Open) {
-          channels_->beginClose(i, ChannelCloseReason::Error);
+        session_->unlock();
+
+        // Check EAGAIN stall timeout (outside lock)
+        if (ch.firstEagainMs > 0 &&
+            (millis() - ch.firstEagainMs) >
+                static_cast<unsigned long>(EAGAIN_STALL_TIMEOUT_MS)) {
+          LOGF_W("SSH",
+                 "Channel %d: EAGAIN stall timeout (%dms, toRemote=%zu)", i,
+                 EAGAIN_STALL_TIMEOUT_MS, ch.toRemote->size());
+          if (ch.state == ChannelSlot::State::Open) {
+            channels_->beginClose(i, ChannelCloseReason::Error);
+          }
+          ch.firstEagainMs = millis();
         }
-        ch.firstEagainMs = millis();
       }
     }
 
-    // Check backpressure on toRemote
+    // Check backpressure on toRemote (no lock needed)
     if (ch.toRemote) {
       size_t used = ch.toRemote->size();
       size_t cap = ch.toRemote->capacityBytes();
@@ -335,9 +342,7 @@ void TransportPump::drainLocalToSsh() {
       }
     }
 
-    // --- Step B: Read from local socket -> toRemote ring ---
-    // Continue reading even when remoteEof is set or state is Draining.
-    // The local web server may still be sending the HTTP response.
+    // --- Step B: Read from local socket -> toRemote ring (no lock needed) ---
     if (!ch.localEof && !ch.localReadPaused && ch.localSocket >= 0 &&
         ch.toRemote) {
       size_t freeSpace = ch.toRemote->available();
@@ -349,7 +354,6 @@ void TransportPump::drainLocalToSsh() {
           ch.lastActivity = millis();
           lastBytesMoved_ += recvd;
         } else if (recvd == 0) {
-          // Local socket closed — the response is fully sent
           ch.localEof = true;
           LOGF_I("SSH", "Channel %d: local EOF", i);
         } else if (errno != EAGAIN && errno != EWOULDBLOCK) {
@@ -361,7 +365,6 @@ void TransportPump::drainLocalToSsh() {
     }
   }
 
-  session_->unlock();
   roundRobinOffset_++;
 }
 
@@ -492,21 +495,18 @@ void TransportPump::checkCloses() {
 
       // Send SSH EOF to signal "no more data from us"
       int rc = libssh2_channel_send_eof(ch.sshChannel);
-      if (rc == 0 || rc == LIBSSH2_ERROR_EAGAIN) {
-        // Retry EAGAIN a few times
-        for (int retry = 0; rc == LIBSSH2_ERROR_EAGAIN && retry < 10; retry++) {
-          rc = libssh2_channel_send_eof(ch.sshChannel);
-        }
+      if (rc == LIBSSH2_ERROR_EAGAIN) {
+        // Don't spin — will retry on the next loop() cycle
+        continue;
       }
 
       // Pump SSH transport to flush any pending outgoing data.
       // libssh2_channel_read() as a side effect processes the outgoing queue.
       uint8_t pumpBuf[512];
-      for (int p = 0; p < 8; p++) {
+      for (int p = 0; p < 4; p++) {
         int pr = libssh2_channel_read(ch.sshChannel, (char *)pumpBuf,
                                       sizeof(pumpBuf));
         if (pr > 0 && ch.toLocal) {
-          // Got some data — put it in the ring (will be drained next cycle)
           ch.toLocal->write(reinterpret_cast<uint8_t *>(pumpBuf), pr);
         }
         if (pr == LIBSSH2_ERROR_EAGAIN || pr <= 0) {

--- a/src/ssh_transport.cpp
+++ b/src/ssh_transport.cpp
@@ -285,6 +285,10 @@ void TransportPump::drainLocalToSsh() {
     }
 
     // --- Step A: Drain toRemote -> SSH (requires session lock) ---
+    // Skip if SSH EOF already sent — writes would fail with error -27
+    if (ch.eofSentMs > 0) {
+      continue;
+    }
     if (ch.toRemote && !ch.toRemote->empty()) {
       if (session_->lock(pdMS_TO_TICKS(20))) {
         size_t budget = MAX_WRITE_PER_CHANNEL;
@@ -363,8 +367,9 @@ void TransportPump::drainLocalToSsh() {
     }
 
     // --- Step B: Read from local socket -> toRemote ring (no lock needed) ---
+    // Skip if channel is draining with EOF sent — no point reading more data
     if (!ch.localEof && !ch.localReadPaused && ch.localSocket >= 0 &&
-        ch.toRemote) {
+        ch.toRemote && ch.eofSentMs == 0) {
       size_t freeSpace = ch.toRemote->available();
       if (freeSpace > 0) {
         size_t readSize = freeSpace < bufSize_ ? freeSpace : bufSize_;

--- a/src/ssh_transport.cpp
+++ b/src/ssh_transport.cpp
@@ -119,8 +119,20 @@ void TransportPump::pumpSshTransport() {
         LOGF_D("SSH", "Channel %d: SSH read resumed (toLocal=%zu)", i,
                ch.toLocal->size());
       } else {
-        // Do NOT read from this channel — it would discard real data.
-        // Transport pumping is handled by reads on other (non-paused) channels.
+        // Pump transport with a small read — store data safely in toLocal
+        // (ring is at ~75%, not 100%, so there's room for a small read).
+        // This processes WINDOW_ADJUST packets that unblock SSH writes.
+        if (ch.toLocal && ch.toLocal->available() > 0) {
+          size_t pumpSize = ch.toLocal->available() < 64
+                                ? ch.toLocal->available()
+                                : 64;
+          int rc =
+              libssh2_channel_read(ch.sshChannel, (char *)rxBuf_, pumpSize);
+          if (rc > 0) {
+            ch.toLocal->write(rxBuf_, rc);
+          }
+        }
+        anyReadDone = true;
         continue;
       }
     }
@@ -184,17 +196,14 @@ void TransportPump::pumpSshTransport() {
   }
 
   // Fallback: if no channel was read (all paused, no remoteEof channels),
-  // we still need to pump the SSH transport to process WINDOW_ADJUST packets
-  // that unblock writes on other channels.  Pick the first active channel
-  // and do a tiny read — for remoteEof channels this is safe (no useful data);
-  // for paused channels the data is already in libssh2's buffer and a 0-byte
-  // read still pumps the transport internally.
+  // pump the transport via a 1-byte read on a remoteEof channel (safe, no
+  // useful data left) or any active channel as last resort.
   if (!anyReadDone) {
     for (int i = 0; i < maxSlots; ++i) {
       ChannelSlot &ch = channels_->getSlot(i);
-      if (ch.active && ch.sshChannel) {
+      if (ch.active && ch.sshChannel && ch.remoteEof) {
         char pumpBuf[1];
-        libssh2_channel_read(ch.sshChannel, pumpBuf, 0);
+        libssh2_channel_read(ch.sshChannel, pumpBuf, sizeof(pumpBuf));
         break;
       }
     }

--- a/src/ssh_transport.cpp
+++ b/src/ssh_transport.cpp
@@ -123,9 +123,8 @@ void TransportPump::pumpSshTransport() {
         // (ring is at ~75%, not 100%, so there's room for a small read).
         // This processes WINDOW_ADJUST packets that unblock SSH writes.
         if (ch.toLocal && ch.toLocal->available() > 0) {
-          size_t pumpSize = ch.toLocal->available() < 64
-                                ? ch.toLocal->available()
-                                : 64;
+          size_t pumpSize =
+              ch.toLocal->available() < 64 ? ch.toLocal->available() : 64;
           int rc =
               libssh2_channel_read(ch.sshChannel, (char *)rxBuf_, pumpSize);
           if (rc > 0) {

--- a/src/ssh_transport.cpp
+++ b/src/ssh_transport.cpp
@@ -183,23 +183,6 @@ void TransportPump::pumpSshTransport() {
     }
   }
 
-  // Fallback: if no channel was read (all paused, no remoteEof channels),
-  // we still need to pump the SSH transport to process WINDOW_ADJUST packets
-  // that unblock writes on other channels.  Pick the first active channel
-  // and do a tiny read — for remoteEof channels this is safe (no useful data);
-  // for paused channels the data is already in libssh2's buffer and a 0-byte
-  // read still pumps the transport internally.
-  if (!anyReadDone) {
-    for (int i = 0; i < maxSlots; ++i) {
-      ChannelSlot &ch = channels_->getSlot(i);
-      if (ch.active && ch.sshChannel) {
-        char pumpBuf[1];
-        libssh2_channel_read(ch.sshChannel, pumpBuf, 0);
-        break;
-      }
-    }
-  }
-
   session_->unlock();
 }
 

--- a/src/ssh_transport.cpp
+++ b/src/ssh_transport.cpp
@@ -308,8 +308,8 @@ void TransportPump::drainLocalToSsh() {
             ch.firstEagainMs = 0;
             ch.consecutiveErrors = 0;
             if (static_cast<size_t>(written) < got) {
-              if (ch.toRemote->writeToFront(txBuf_ + written,
-                                            got - written) == 0) {
+              if (ch.toRemote->writeToFront(txBuf_ + written, got - written) ==
+                  0) {
                 ch.toRemote->write(txBuf_ + written, got - written);
               }
               break;
@@ -336,9 +336,8 @@ void TransportPump::drainLocalToSsh() {
         if (ch.firstEagainMs > 0 &&
             (millis() - ch.firstEagainMs) >
                 static_cast<unsigned long>(EAGAIN_STALL_TIMEOUT_MS)) {
-          LOGF_W("SSH",
-                 "Channel %d: EAGAIN stall timeout (%dms, toRemote=%zu)", i,
-                 EAGAIN_STALL_TIMEOUT_MS, ch.toRemote->size());
+          LOGF_W("SSH", "Channel %d: EAGAIN stall timeout (%dms, toRemote=%zu)",
+                 i, EAGAIN_STALL_TIMEOUT_MS, ch.toRemote->size());
           if (ch.state == ChannelSlot::State::Open) {
             channels_->beginClose(i, ChannelCloseReason::Error);
           }

--- a/src/ssh_transport.cpp
+++ b/src/ssh_transport.cpp
@@ -119,10 +119,8 @@ void TransportPump::pumpSshTransport() {
         LOGF_D("SSH", "Channel %d: SSH read resumed (toLocal=%zu)", i,
                ch.toLocal->size());
       } else {
-        // Still do a transport pump read even when paused
-        char pumpBuf[64];
-        libssh2_channel_read(ch.sshChannel, pumpBuf, sizeof(pumpBuf));
-        anyReadDone = true;
+        // Do NOT read from this channel — it would discard real data.
+        // Transport pumping is handled by reads on other (non-paused) channels.
         continue;
       }
     }
@@ -185,6 +183,23 @@ void TransportPump::pumpSshTransport() {
     }
   }
 
+  // Fallback: if no channel was read (all paused, no remoteEof channels),
+  // we still need to pump the SSH transport to process WINDOW_ADJUST packets
+  // that unblock writes on other channels.  Pick the first active channel
+  // and do a tiny read — for remoteEof channels this is safe (no useful data);
+  // for paused channels the data is already in libssh2's buffer and a 0-byte
+  // read still pumps the transport internally.
+  if (!anyReadDone) {
+    for (int i = 0; i < maxSlots; ++i) {
+      ChannelSlot &ch = channels_->getSlot(i);
+      if (ch.active && ch.sshChannel) {
+        char pumpBuf[1];
+        libssh2_channel_read(ch.sshChannel, pumpBuf, 0);
+        break;
+      }
+    }
+  }
+
   session_->unlock();
 }
 
@@ -206,37 +221,43 @@ void TransportPump::drainSshToLocal() {
       continue;
     }
 
-    if (ch.toLocal->empty()) {
-      continue;
-    }
-
-    size_t available = ch.toLocal->size();
-    size_t toDrain = available < bufSize_ ? available : bufSize_;
-
-    size_t got = ch.toLocal->read(txBuf_, toDrain);
-    if (got == 0) {
-      continue;
-    }
-
-    ssize_t sent = send(ch.localSocket, txBuf_, got, MSG_DONTWAIT);
-    if (sent > 0) {
-      lastBytesMoved_ += sent;
-      ch.lastActivity = millis();
-      if (static_cast<size_t>(sent) < got) {
-        // Partial send: put unsent data back at the front of the ring
-        if (ch.toLocal->writeToFront(txBuf_ + sent, got - sent) == 0) {
-          // Prepend buffer occupied — re-append to preserve data
-          ch.toLocal->write(txBuf_ + sent, got - sent);
-        }
+    // Drain up to 4 chunks per channel to match Phase 1's read throughput
+    for (int attempt = 0; attempt < 4; ++attempt) {
+      if (ch.toLocal->empty()) {
+        break;
       }
-    } else if (sent < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
-      ch.localEof = true;
-      LOGF_W("SSH", "Channel %d: local send error %d (%s)", i, errno,
-             strerror(errno));
-    } else {
-      // EAGAIN/EWOULDBLOCK: put ALL data back at the front
-      if (ch.toLocal->writeToFront(txBuf_, got) == 0) {
-        ch.toLocal->write(txBuf_, got);
+
+      size_t available = ch.toLocal->size();
+      size_t toDrain = available < bufSize_ ? available : bufSize_;
+
+      size_t got = ch.toLocal->read(txBuf_, toDrain);
+      if (got == 0) {
+        break;
+      }
+
+      ssize_t sent = send(ch.localSocket, txBuf_, got, MSG_DONTWAIT);
+      if (sent > 0) {
+        lastBytesMoved_ += sent;
+        ch.lastActivity = millis();
+        if (static_cast<size_t>(sent) < got) {
+          // Partial send: put unsent data back at the front of the ring
+          if (ch.toLocal->writeToFront(txBuf_ + sent, got - sent) == 0) {
+            // Prepend buffer occupied — re-append to preserve data
+            ch.toLocal->write(txBuf_ + sent, got - sent);
+          }
+          break; // Socket can't take more right now
+        }
+      } else if (sent < 0 && errno != EAGAIN && errno != EWOULDBLOCK) {
+        ch.localEof = true;
+        LOGF_W("SSH", "Channel %d: local send error %d (%s)", i, errno,
+               strerror(errno));
+        break;
+      } else {
+        // EAGAIN/EWOULDBLOCK: put ALL data back at the front
+        if (ch.toLocal->writeToFront(txBuf_, got) == 0) {
+          ch.toLocal->write(txBuf_, got);
+        }
+        break; // Socket busy, stop draining this channel
       }
     }
   }

--- a/src/ssh_transport.cpp
+++ b/src/ssh_transport.cpp
@@ -183,6 +183,23 @@ void TransportPump::pumpSshTransport() {
     }
   }
 
+  // Fallback: if no channel was read (all paused, no remoteEof channels),
+  // we still need to pump the SSH transport to process WINDOW_ADJUST packets
+  // that unblock writes on other channels.  Pick the first active channel
+  // and do a tiny read — for remoteEof channels this is safe (no useful data);
+  // for paused channels the data is already in libssh2's buffer and a 0-byte
+  // read still pumps the transport internally.
+  if (!anyReadDone) {
+    for (int i = 0; i < maxSlots; ++i) {
+      ChannelSlot &ch = channels_->getSlot(i);
+      if (ch.active && ch.sshChannel) {
+        char pumpBuf[1];
+        libssh2_channel_read(ch.sshChannel, pumpBuf, 0);
+        break;
+      }
+    }
+  }
+
   session_->unlock();
 }
 

--- a/src/ssh_transport.h
+++ b/src/ssh_transport.h
@@ -64,7 +64,7 @@ private:
   static constexpr int BACKPRESSURE_HIGH_PCT = 75; // Pause reads above 75%
   static constexpr int BACKPRESSURE_LOW_PCT = 25;  // Resume reads below 25%
   static constexpr size_t MAX_WRITE_PER_CHANNEL =
-      4096; // Max SSH write per channel per round
+      16384; // Max SSH write per channel per round
   static constexpr unsigned long DRAIN_TIMEOUT_MS =
       15000; // Max time in Draining state
   static constexpr unsigned long HALF_CLOSE_TIMEOUT_MS =

--- a/src/ssh_transport.h
+++ b/src/ssh_transport.h
@@ -68,9 +68,9 @@ private:
   static constexpr unsigned long DRAIN_TIMEOUT_MS =
       15000; // Max time in Draining state
   static constexpr unsigned long HALF_CLOSE_TIMEOUT_MS =
-      10000; // Close after remote EOF + 10s idle
+      3000; // Close after remote EOF + 3s idle (HTTP responses complete fast)
   static constexpr int EAGAIN_STALL_TIMEOUT_MS =
-      30000; // Max EAGAIN duration before close
+      10000; // Max EAGAIN duration before close (detect dead channels faster)
   static constexpr unsigned long EOF_GRACE_MS =
       200; // Wait after SSH EOF sent before closing
 

--- a/src/ssh_tunnel.cpp
+++ b/src/ssh_tunnel.cpp
@@ -217,9 +217,9 @@ void SSHTunnel::loop() {
     drainDeferredCloseQueue();
   }
 
-  // Accept new connections (drain all pending channels from libssh2)
-  while (handleNewConnection()) {
-    // keep accepting until no more pending channels
+  // Accept new connections (up to 3 per loop to avoid heap fragmentation
+  // from rapid ring buffer allocation/deallocation in PSRAM)
+  for (int accepts = 0; accepts < 3 && handleNewConnection(); ++accepts) {
   }
 
   // Pump all data (the core of the new architecture)

--- a/src/ssh_tunnel.cpp
+++ b/src/ssh_tunnel.cpp
@@ -418,7 +418,8 @@ void SSHTunnel::drainPendingQueue() {
           continue;
         }
         // Lock failed — keep in queue for next attempt (don't leak the pointer)
-        LOGF_W("SSH", "Lock unavailable for expired close, retrying next cycle");
+        LOGF_W("SSH",
+               "Lock unavailable for expired close, retrying next cycle");
         if (writeIdx != i) {
           pendingQueue_[writeIdx] = pending;
         }

--- a/src/ssh_tunnel.cpp
+++ b/src/ssh_tunnel.cpp
@@ -339,18 +339,22 @@ bool SSHTunnel::handleNewConnection() {
                pendingCount_, MAX_PENDING);
         return false;
       }
+      // Pending queue full + lock unavailable: queue as Close, don't destroy
+      // the tunnel for transient contention
+      if (!enqueueDeferredClose(ch, mapping,
+                                "Deferring close: lock unavailable and "
+                                "pending queue full")) {
+        LOG_W("SSH", "All queues full, dropping channel (transient)");
+      }
+      return false;
     }
 
     // Bind failure means the local endpoint or channel resources are not
-    // usable right now. Keeping the SSH channel queued only makes the remote
-    // client hang until the pending timeout expires.
+    // usable right now — close the channel, don't keep it hanging.
     if (!enqueueDeferredClose(ch, mapping,
-                              bindResult == BindResult::Failed
-                                  ? "Rejecting accepted channel after bind "
-                                    "failure"
-                                  : "Deferring close of accepted channel "
-                                    "because session lock is unavailable")) {
-      enterErrorState("deferred close queue full");
+                              "Rejecting accepted channel after bind "
+                              "failure")) {
+      LOG_W("SSH", "Deferred close queue full, dropping channel");
     }
     return false;
   }
@@ -368,17 +372,21 @@ bool SSHTunnel::handleNewConnection() {
     return false;
   }
 
-  // Queue is also full — reject the connection
+  // Queue is also full — reject the connection, but don't destroy the tunnel
   LOG_W("SSH", "Pending queue full, rejecting connection");
   if (!closeAcceptedChannel(session_, ch, pdMS_TO_TICKS(500), nullptr) &&
       !enqueueDeferredClose(ch, mapping,
                             "Pending queue full and close deferred")) {
-    enterErrorState("pending queue overflow while deferring close");
+    // All queues saturated — last resort: leak the channel rather than
+    // tearing down the entire tunnel for a transient overload.
+    LOG_E("SSH", "All queues full, channel leaked (will be freed on session "
+                 "disconnect)");
   }
   return false;
 }
 
 void SSHTunnel::drainPendingQueue() {
+  unsigned long now = millis();
   int writeIdx = 0;
   for (int i = 0; i < pendingCount_; ++i) {
     PendingChannel &pending = pendingQueue_[i];
@@ -388,6 +396,18 @@ void SSHTunnel::drainPendingQueue() {
     }
 
     if (pending.action == PendingChannel::Action::Close) {
+      unsigned long age = now - pending.queuedAtMs;
+      if (age > CLOSE_RETRY_TIMEOUT_MS) {
+        // Close retry timed out — force-free with session lock or abandon
+        LOGF_W("SSH",
+               "Pending close entry expired after %lums, force-freeing", age);
+        if (session_.lock(pdMS_TO_TICKS(100))) {
+          libssh2_channel_free(pending.channel);
+          session_.unlock();
+        }
+        pending.channel = nullptr;
+        continue;
+      }
       if (!closeAcceptedChannel(session_, pending.channel, pdMS_TO_TICKS(200),
                                 "Retrying deferred close of queued channel")) {
         if (writeIdx != i) {
@@ -400,7 +420,6 @@ void SSHTunnel::drainPendingQueue() {
       continue;
     }
 
-    unsigned long now = millis();
     if ((now - pending.queuedAtMs) > PENDING_TIMEOUT_MS) {
       LOGF_W("SSH", "Pending channel expired after %lums, dropping",
              now - pending.queuedAtMs);
@@ -465,10 +484,22 @@ void SSHTunnel::drainPendingQueue() {
 }
 
 void SSHTunnel::drainDeferredCloseQueue() {
+  unsigned long now = millis();
   int writeIdx = 0;
   for (int i = 0; i < deferredCloseCount_; ++i) {
     PendingChannel &pending = deferredCloseQueue_[i];
     if (!pending.channel) {
+      continue;
+    }
+    unsigned long age = now - pending.queuedAtMs;
+    if (age > CLOSE_RETRY_TIMEOUT_MS) {
+      LOGF_W("SSH",
+             "Deferred close entry expired after %lums, force-freeing", age);
+      if (session_.lock(pdMS_TO_TICKS(100))) {
+        libssh2_channel_free(pending.channel);
+        session_.unlock();
+      }
+      pending.channel = nullptr;
       continue;
     }
     if (!closeAcceptedChannel(session_, pending.channel, pdMS_TO_TICKS(200),

--- a/src/ssh_tunnel.cpp
+++ b/src/ssh_tunnel.cpp
@@ -217,10 +217,9 @@ void SSHTunnel::loop() {
     drainDeferredCloseQueue();
   }
 
-  // Accept new connections (up to 3 per loop to avoid heap fragmentation
-  // from rapid ring buffer allocation/deallocation in PSRAM)
-  for (int accepts = 0; accepts < 3 && handleNewConnection(); ++accepts) {
-  }
+  // Accept new connections (one per loop to avoid PSRAM heap fragmentation
+  // from rapid ring buffer allocation cycles)
+  handleNewConnection();
 
   // Pump all data (the core of the new architecture)
   transport_.pumpAll();

--- a/src/ssh_tunnel.cpp
+++ b/src/ssh_tunnel.cpp
@@ -401,8 +401,8 @@ void SSHTunnel::drainPendingQueue() {
       unsigned long age = now - pending.queuedAtMs;
       if (age > CLOSE_RETRY_TIMEOUT_MS) {
         // Close retry timed out — force-free with session lock or abandon
-        LOGF_W("SSH",
-               "Pending close entry expired after %lums, force-freeing", age);
+        LOGF_W("SSH", "Pending close entry expired after %lums, force-freeing",
+               age);
         if (session_.lock(pdMS_TO_TICKS(100))) {
           libssh2_channel_free(pending.channel);
           session_.unlock();
@@ -495,8 +495,8 @@ void SSHTunnel::drainDeferredCloseQueue() {
     }
     unsigned long age = now - pending.queuedAtMs;
     if (age > CLOSE_RETRY_TIMEOUT_MS) {
-      LOGF_W("SSH",
-             "Deferred close entry expired after %lums, force-freeing", age);
+      LOGF_W("SSH", "Deferred close entry expired after %lums, force-freeing",
+             age);
       if (session_.lock(pdMS_TO_TICKS(100))) {
         libssh2_channel_free(pending.channel);
         session_.unlock();

--- a/src/ssh_tunnel.cpp
+++ b/src/ssh_tunnel.cpp
@@ -217,8 +217,10 @@ void SSHTunnel::loop() {
     drainDeferredCloseQueue();
   }
 
-  // Accept new connections
-  handleNewConnection();
+  // Accept new connections (drain all pending channels from libssh2)
+  while (handleNewConnection()) {
+    // keep accepting until no more pending channels
+  }
 
   // Pump all data (the core of the new architecture)
   transport_.pumpAll();

--- a/src/ssh_tunnel.cpp
+++ b/src/ssh_tunnel.cpp
@@ -217,9 +217,10 @@ void SSHTunnel::loop() {
     drainDeferredCloseQueue();
   }
 
-  // Accept new connections (one per loop to avoid PSRAM heap fragmentation
-  // from rapid ring buffer allocation cycles)
-  handleNewConnection();
+  // Accept new connections (drain all pending channels from libssh2)
+  while (handleNewConnection()) {
+    // keep accepting until no more pending channels
+  }
 
   // Pump all data (the core of the new architecture)
   transport_.pumpAll();

--- a/src/ssh_tunnel.cpp
+++ b/src/ssh_tunnel.cpp
@@ -379,10 +379,17 @@ bool SSHTunnel::handleNewConnection() {
   if (!closeAcceptedChannel(session_, ch, pdMS_TO_TICKS(500), nullptr) &&
       !enqueueDeferredClose(ch, mapping,
                             "Pending queue full and close deferred")) {
-    // All queues saturated — last resort: leak the channel rather than
-    // tearing down the entire tunnel for a transient overload.
-    LOG_E("SSH", "All queues full, channel leaked (will be freed on session "
-                 "disconnect)");
+    // All queues saturated — last resort: force-close with a longer lock wait
+    // rather than leaking the channel pointer permanently.
+    LOG_E("SSH", "All queues full, attempting force-close with extended wait");
+    if (session_.lock(pdMS_TO_TICKS(1000))) {
+      libssh2_channel_close(ch);
+      libssh2_channel_free(ch);
+      session_.unlock();
+    } else {
+      // Truly cannot free — the channel will be reclaimed on session disconnect
+      LOG_E("SSH", "Force-close failed, channel will be freed on disconnect");
+    }
   }
   return false;
 }
@@ -400,14 +407,22 @@ void SSHTunnel::drainPendingQueue() {
     if (pending.action == PendingChannel::Action::Close) {
       unsigned long age = now - pending.queuedAtMs;
       if (age > CLOSE_RETRY_TIMEOUT_MS) {
-        // Close retry timed out — force-free with session lock or abandon
+        // Close retry timed out — force-free with session lock
         LOGF_W("SSH", "Pending close entry expired after %lums, force-freeing",
                age);
         if (session_.lock(pdMS_TO_TICKS(100))) {
+          libssh2_channel_close(pending.channel);
           libssh2_channel_free(pending.channel);
           session_.unlock();
+          pending.channel = nullptr;
+          continue;
         }
-        pending.channel = nullptr;
+        // Lock failed — keep in queue for next attempt (don't leak the pointer)
+        LOGF_W("SSH", "Lock unavailable for expired close, retrying next cycle");
+        if (writeIdx != i) {
+          pendingQueue_[writeIdx] = pending;
+        }
+        writeIdx++;
         continue;
       }
       if (!closeAcceptedChannel(session_, pending.channel, pdMS_TO_TICKS(200),
@@ -498,10 +513,18 @@ void SSHTunnel::drainDeferredCloseQueue() {
       LOGF_W("SSH", "Deferred close entry expired after %lums, force-freeing",
              age);
       if (session_.lock(pdMS_TO_TICKS(100))) {
+        libssh2_channel_close(pending.channel);
         libssh2_channel_free(pending.channel);
         session_.unlock();
+        pending.channel = nullptr;
+        continue;
       }
-      pending.channel = nullptr;
+      // Lock failed — keep in queue for next attempt (don't leak the pointer)
+      LOGF_W("SSH", "Lock unavailable for expired deferred close, retrying");
+      if (writeIdx != i) {
+        deferredCloseQueue_[writeIdx] = pending;
+      }
+      writeIdx++;
       continue;
     }
     if (!closeAcceptedChannel(session_, pending.channel, pdMS_TO_TICKS(200),

--- a/src/ssh_tunnel.h
+++ b/src/ssh_tunnel.h
@@ -68,6 +68,8 @@ public:
   unsigned long getBytesSent();
   unsigned long getBytesDropped();
   int getActiveChannels();
+  int getKeepAliveFailures() const { return session_.getKeepAliveFailures(); }
+  int getSocketHealthFailures() const { return socketHealthFailures_; }
 
   // Event handlers
   void setEventHandlers(const SSHTunnelEvents &handlers);

--- a/src/ssh_tunnel.h
+++ b/src/ssh_tunnel.h
@@ -138,7 +138,8 @@ private:
   // Pending connection queue
   static constexpr int MAX_PENDING = 8;
   static constexpr int MAX_DEFERRED_CLOSE = 4;
-  static constexpr unsigned long PENDING_TIMEOUT_MS = 30000;
+  static constexpr unsigned long PENDING_TIMEOUT_MS = 5000;
+  static constexpr unsigned long CLOSE_RETRY_TIMEOUT_MS = 5000;
   PendingChannel pendingQueue_[MAX_PENDING];
   int pendingCount_ = 0;
   PendingChannel deferredCloseQueue_[MAX_DEFERRED_CLOSE];


### PR DESCRIPTION
This pull request introduces several reliability and performance improvements to the ESP-Reverse_Tunneling_Libssh2 library, focusing on more robust non-blocking socket handling, better resource management during high-load or error conditions, and improved responsiveness for typical HTTP tunneling use cases. It also exposes new diagnostic metrics and updates timeouts to ensure faster recovery from network stalls or overloads.

**Socket and Channel Handling Improvements:**

- Changed the local endpoint connection logic in `ChannelManager::connectToLocalEndpoint` to set sockets to non-blocking mode before connecting, and implemented a short timeout (2s) for connect completion using `select()`. This prevents long stalls in the main loop and improves responsiveness if the endpoint is unreachable.
- Enhanced channel draining and buffer management in `TransportPump` to ensure that partial writes or buffer full conditions do not result in data loss, and that data is always preserved if the ring buffer is full. [[1]](diffhunk://#diff-e6aa45339be78f8269806a492288952b5907125719ca8b87096624ec6dd9b0e1L227-R261) [[2]](diffhunk://#diff-e6aa45339be78f8269806a492288952b5907125719ca8b87096624ec6dd9b0e1L290-R320)
- Improved SSH transport pumping logic to avoid discarding real data when all channels are paused, and added a fallback to always pump the transport even if no channel was read, ensuring smooth flow control and preventing stalls. [[1]](diffhunk://#diff-e6aa45339be78f8269806a492288952b5907125719ca8b87096624ec6dd9b0e1L122-R123) [[2]](diffhunk://#diff-e6aa45339be78f8269806a492288952b5907125719ca8b87096624ec6dd9b0e1R186-R202)

**Queue and Resource Management:**

- Refined pending and deferred close queue handling: when queues are full or locks are unavailable, channels are now deferred for close instead of immediately destroying the tunnel, and channels are force-freed if they remain in the queue too long (5s). This prevents resource leaks and tunnel teardown during transient overloads. [[1]](diffhunk://#diff-e90a5b3782a09657f610b05ddb47f571f40adb1551faf27e36f11cebcbccd80fR344-R359) [[2]](diffhunk://#diff-e90a5b3782a09657f610b05ddb47f571f40adb1551faf27e36f11cebcbccd80fR401-R412) [[3]](diffhunk://#diff-e90a5b3782a09657f610b05ddb47f571f40adb1551faf27e36f11cebcbccd80fR489-R506)
- Reduced pending channel timeout from 30s to 5s, and added a 5s retry timeout for deferred closes, making the system more responsive to overloads and minimizing resource retention.

**Performance and Timeout Adjustments:**

- Lowered the half-close timeout from 10s to 3s and the EAGAIN stall timeout from 30s to 10s, enabling faster detection and cleanup of dead or stalled channels, which is especially beneficial for short-lived HTTP tunnels.
- Updated the logic for accepting new SSH connections to drain all pending channels in a loop, ensuring no backlog remains in libssh2.

**Diagnostics and API Additions:**

- Exposed the number of consecutive keepalive failures and socket health failures via new getters in `SSHSession` and `SSHTunnel`, providing better diagnostics for tunnel health monitoring. [[1]](diffhunk://#diff-196602d9147cc70215c803e465abce7a3c9f718aa816b288266c218cadd74e3aR42-R44) [[2]](diffhunk://#diff-9c0ddda179c692c1c2f659252c24385ca74686c97d2c5763609d9b3349465e55R71-R72)

**Versioning:**

- Bumped the library version to 2.1.2 in both `library.json` and `library.properties` to reflect these changes. [[1]](diffhunk://#diff-64cc7cdde6789dc1c1c4a6f406cd1ff6a6a00027097788e2d52fc27b0d75502eL3-R3) [[2]](diffhunk://#diff-f267f9ae2f5d5d56a1dbb305e95d40d4408d9ee7f71357f1f67fb18c29b7f082L2-R2)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Exposed runtime health metrics for keepalive and socket failures.
  * Increased per-channel write throughput limit.

* **Bug Fixes**
  * More reliable non-blocking connection setup with explicit timeout handling.
  * Improved transport draining, backpressure and retry behavior to prevent data loss.
  * Better deferred/force-close handling and queue expiration to avoid stuck channels.

* **Chores**
  * Version bumped to 2.1.2.
  * Reduced several timeouts for faster responsiveness.
  * Removed local CLI settings and added .claude/ to .gitignore.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->